### PR TITLE
[FIX] 회원가입-로그인 뷰의 TextInputLayout에 Space가 생기는 버그 수정

### DIFF
--- a/presentation/src/main/res/layout/fragment_sign_in.xml
+++ b/presentation/src/main/res/layout/fragment_sign_in.xml
@@ -61,6 +61,7 @@
 
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/til_email_sign_in"
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         app:boxStrokeWidth="0dp"
@@ -113,6 +114,7 @@
 
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/til_validate_code_sign_in"
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="3"

--- a/presentation/src/main/res/layout/fragment_sign_up.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up.xml
@@ -107,6 +107,7 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/til_nickname_sign_up"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:boxStrokeWidth="0dp"
@@ -121,9 +122,9 @@
                         style="@style/TextEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@={vm.nickname}"
+                        android:hint="@string/please_set_nickname"
                         android:inputType="textPersonName"
-                        android:hint="@string/please_set_nickname" />
+                        android:text="@={vm.nickname}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -59,12 +59,14 @@
         <item name="android:textSize">15sp</item>
         <item name="boxBackgroundMode">none</item>
         <item name="android:background">@drawable/edt_box</item>
+        <item name="android:paddingVertical">16dp</item>
     </style>
 
     <style name="OutlinedButton" parent="TextAppearance.AppCompat.Button">
         <item name="android:background">@drawable/btn_outlined_box</item>
-        <item name="android:layout_height">56dp</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:textColor">@color/main</item>
+        <item name="android:paddingVertical">17dp</item>
     </style>
 
     <style name="TextButton" parent="TextAppearance.AppCompat.Button">


### PR DESCRIPTION
실기기 빌드시 텍스트 인풋레이아웃의 윗 부분에 빈 공간이 생기는 버그를 수정하였습니다.

![Screenshot_20211009-115953_Air](https://user-images.githubusercontent.com/18213322/136642107-9697ef24-41d2-457a-92fe-ec85b79381f5.jpg)

fix #54